### PR TITLE
Follow app directory for `uuid`

### DIFF
--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -28,7 +28,7 @@ extern PlayState* gPlayState;
 }
 
 ArchipelagoClient::ArchipelagoClient() {
-    uuid = ap_get_uuid("uuid");
+    uuid = ap_get_uuid(Ship::Context::GetPathRelativeToAppDirectory("uuid"));
 
     gameWon = false;
     itemQueued = false;


### PR DESCRIPTION
This PR is similar to https://github.com/HarbourMasters/Shipwright/pull/5693 but for the Archipelago `uuid` file. Stores `uuid` in the app directory instead of the current working directory.