### PR TITLE
temporarily force errors instead of disabling `BUILD_REMOTE_CONTROL`

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -318,7 +318,8 @@ if (BUILD_REMOTE_CONTROL)
     find_package(SDL2_net)
 
     if(NOT SDL2_net_FOUND)
-        message(STATUS "SDL2_net not found (it's possible the version installed is too old). Disabling BUILD_REMOTE_CONTROL.")
+        # todo: make archi optional so this can build with BUILD_REMOTE_CONTROL off
+        message(FATAL_ERROR "SDL2_net not found (it's possible the version installed is too old).")
         set(BUILD_REMOTE_CONTROL 0)
     else()
         set(SDL2-NET-INCLUDE ${SDL_NET_INCLUDE_DIRS})
@@ -337,7 +338,8 @@ if (BUILD_REMOTE_CONTROL)
 
     find_package(OpenSSL)
     if(NOT OPENSSL_FOUND)
-        message(STATUS "OpenSSL not found (it's possible the version installed is too old). Disabling BUILD_REMOTE_CONTROL.")
+        # todo: make archi optional so this can build with BUILD_REMOTE_CONTROL off
+        message(FATAL_ERROR "OpenSSL not found (it's possible the version installed is too old).")
         set(BUILD_REMOTE_CONTROL 0)
     endif()
 


### PR DESCRIPTION
i didn't have sdl net installed on my new dev machine and ended up hitting a wild linker error. the issue boiled down to:
* openssl libs are only linked when `BUILD_REMOTE_CONTROL` is on
* not having sdl net installed turns `BUILD_REMOTE_CONTROL` off
* the current code archi code is always included, and relies on having those openssl libs linked
* :boom: linker error :boom: 

if this had been in there, i would have gotten a cmake `FATAL_ERROR` instead and the message would have told me to install sdl net 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/aMannus/Shipwright/actions/artifacts/4122674674.zip)
  - [soh-windows.zip](https://nightly.link/aMannus/Shipwright/actions/artifacts/4122694623.zip)
  - [soh-mac.zip](https://nightly.link/aMannus/Shipwright/actions/artifacts/4122730107.zip)
<!--- section:artifacts:end -->